### PR TITLE
Use botJoinMessage from config with default being the same as before

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -5,6 +5,7 @@
   // (see readme for more details)
   "matrixServerUrl": "http://localhost:8008/",
   "matrixServerName": "localhost",
+  // "botJoinMessage": "Joining room … See FAQ _" (full default in code)
   // Set this to 100 since that is the max that Synapse will backfill even if you do a
   // `/messages?limit=1000` and we don't want to miss messages in between.
   "messageLimit": 100,

--- a/server/lib/matrix-utils/ensure-room-joined.js
+++ b/server/lib/matrix-utils/ensure-room-joined.js
@@ -16,6 +16,16 @@ assert(matrixServerUrl);
 
 const matrixViewerURLCreator = new MatrixViewerURLCreator(basePath);
 
+const defaultJoinMessage = `Joining room to check history visibility. ` +
+  `If your room is public with shared or world readable history visibility, ` +
+  `it will be accessible on ${matrixViewerURLCreator.roomDirectoryUrl()}. ` +
+  `See the FAQ for more details: ` +
+  `https://github.com/matrix-org/matrix-viewer/blob/main/docs/faq.md#why-did-the-bot-join-my-room`;
+
+config.defaults({
+  botJoinMessage: defaultJoinMessage,
+});
+
 async function ensureRoomJoined(
   accessToken,
   roomIdOrAlias,
@@ -49,12 +59,7 @@ async function ensureRoomJoined(
       accessToken,
       abortSignal,
       body: {
-        reason:
-          `Joining room to check history visibility. ` +
-          `If your room is public with shared or world readable history visibility, ` +
-          `it will be accessible on ${matrixViewerURLCreator.roomDirectoryUrl()}. ` +
-          `See the FAQ for more details: ` +
-          `https://github.com/matrix-org/matrix-viewer/blob/main/docs/faq.md#why-did-the-bot-join-my-room`,
+        reason: config.get("botJoinMessage"),
       },
     });
     assert(


### PR DESCRIPTION
This simply allows to change the reason sent into the room while joining. This may be used by 3rd party instances, e.g. to redirect to different FAQ pages or so.

I’ve tested that this change works and does not interfere with other stuff.