### PR TITLE
Allow restricting an instance to certain rooms

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -21,4 +21,9 @@
 
   // Secrets
   //"matrixAccessToken": "xxx"
+
+  // Restrict to rooms listed below
+  //"enableAllowList": true,
+  // use room ids starting with a `!`, not aliases
+  //"roomAllowList": ["!ypQyNeReyEPUCKYjPU:matrix.org"],  // e.g. room about Matrix Reputation
 }

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -26,4 +26,6 @@
   //"enableAllowList": true,
   // use room ids starting with a `!`, not aliases
   //"roomAllowList": ["!ypQyNeReyEPUCKYjPU:matrix.org"],  // e.g. room about Matrix Reputation
+  // Hide room directory (will enable auto redirect to first entry of allow list)
+  //"hideRoomDirectory": true,
 }

--- a/server/lib/matrix-utils/check-room-allowed.js
+++ b/server/lib/matrix-utils/check-room-allowed.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('assert');
+
+const fetchRoomId = require('./fetch-room-id');
+
+const config = require('../config');
+const basePath = config.get('basePath');
+assert(basePath);
+const matrixServerUrl = config.get('matrixServerUrl');
+assert(matrixServerUrl);
+
+config.defaults({
+  "enableAllowList": false,
+  "roomAllowList": [],
+});
+
+async function checkIfAllowed(roomIdOrAlias) {
+  if (!config.get("enableAllowList")) {
+    return true;
+  }
+  const roomId = await fetchRoomId(roomIdOrAlias);
+  const result = config.get("roomAllowList").includes(roomId)
+  return result;
+}
+
+module.exports = checkIfAllowed;

--- a/server/lib/matrix-utils/ensure-room-joined.js
+++ b/server/lib/matrix-utils/ensure-room-joined.js
@@ -5,6 +5,7 @@ const urlJoin = require('url-join');
 
 const StatusError = require('../errors/status-error');
 const { fetchEndpointAsJson } = require('../fetch-endpoint');
+const checkIfAllowed = require('./check-room-allowed');
 const getServerNameFromMatrixRoomIdOrAlias = require('./get-server-name-from-matrix-room-id-or-alias');
 const MatrixViewerURLCreator = require('matrix-viewer-shared/lib/url-creator');
 
@@ -21,6 +22,11 @@ async function ensureRoomJoined(
   roomIdOrAlias,
   { viaServers = new Set(), abortSignal } = {}
 ) {
+  const result = await checkIfAllowed(roomIdOrAlias);
+  if (!result) {
+    throw new StatusError(403, `Bot is not allowed to view room, room is not listed in explicit allow list.`);
+  }
+
   // We use a `Set` to ensure that we don't have duplicate servers in the list
   assert(viaServers instanceof Set);
 

--- a/server/lib/matrix-utils/fetch-room-id.js
+++ b/server/lib/matrix-utils/fetch-room-id.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('assert');
+const urlJoin = require('url-join');
+
+const StatusError = require('../errors/status-error');
+const { fetchEndpointAsJson } = require('../fetch-endpoint');
+
+const config = require('../config');
+const basePath = config.get('basePath');
+assert(basePath);
+const matrixServerUrl = config.get('matrixServerUrl');
+assert(matrixServerUrl);
+
+config.defaults({
+  "enableAllowlist": false,
+  "roomAllowlist": [],
+});
+
+async function fetchRoomId(
+  roomIdOrAlias,
+) {
+  if (roomIdOrAlias.startsWith("!")) {
+    return roomIdOrAlias;
+  }
+
+  const resolveEndpoint = urlJoin(
+    matrixServerUrl,
+    `_matrix/client/v3/directory/room/${encodeURIComponent(roomIdOrAlias)}`
+  );
+  try {
+    const { data: roomData } = await fetchEndpointAsJson(resolveEndpoint, {
+      method: 'GET',
+    });
+    assert(
+      roomData.room_id,
+      `Alias resolve endpoint (${resolveEndpoint}) did not return \`room_id\` as expected. This is probably a problem with that homeserver.`
+    );
+    return roomData.room_id;
+  } catch (err) {
+    throw new StatusError(403, `Bot is unable to resolve alias of room: ${err.message}`);
+  }
+}
+
+module.exports = fetchRoomId;


### PR DESCRIPTION
This change introduces config options, which allow to restrict which rooms the view bot is allowed to join & render messages from.

For the message preview, the implementation is quite straightforward:
* get the room id (if having an alias)
* check against the list of allowed rooms (if allow list is enabled)
* do stuff the normal way if found
* if not, return 403 to user with explanation, that the bot is not allowed to join & view this room

However, if allowlists are enabled, the UX in the room directory is not perfect. My current implementation just filters out all rooms which are not allowed. However, this may leave the user with less than 9 rooms (most probably even 0) in their search result while the user still needs to press next to search further. However, this seemed a little bit better to me than showing rooms which aren’t accessible.

To avoid this bad UX for certain use cases (most probably useful if projects self-host a small instance for themselves), I introduced a setting which hides the room directory and just redirects to the first allowed room.

I tested that all changes are doing what I intended. I also tested that, with no new settings set, the site still behaves the same.