### PR TITLE
Remove confusing link to different app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Gitter](https://github.com/vector-im/roadmap/issues/26), the goal is to make an
 accessible public site for `world_readable` Matrix rooms like Gitter's archives
 which search engines can index and keep all of the content accessible/available.
 
-#### Try it out: [view.matrix.org](https://view.matrix.org/) 🌌
-
 <!-- prettier-ignore -->
 Room directory homepage | Room view
 --- | ---


### PR DESCRIPTION
After this project was renamed from "Matrix Public Archive" to "Matrix Viewer", it was also planned to move over to the `view.matrix.org` domain but the project was put on hold before that happened. Removing the link to the legacy [`matrix-static`](https://github.com/matrix-org/matrix-static) app that currently lives at `view.matrix.org` is probably the best way to stop confusing people.

See https://github.com/matrix-org/matrix-viewer/issues/284 as an example of someone stumbling to the other app.